### PR TITLE
Replace rvn explorer urls with evr ones

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -121,8 +121,7 @@ static const int MAX_URI_LENGTH = 255;
 #define QAPP_APP_NAME_TESTNET "Evrmore-Qt-testnet"
 
 /* Default third party browser urls */
-// EVR-TODO: Put Evrmore browser URLs here
-#define DEFAULT_THIRD_PARTY_BROWSERS "https://api.ravencoin.org/tx/%s|https://rvn.cryptoscope.io/tx/?txid=%s|https://blockbook.ravencoin.org/tx/%s|https://explorer.mangofarmassets.com/tx/%s|https://www.assetsexplorer.com/tx/%s"
+#define DEFAULT_THIRD_PARTY_BROWSERS "https://evr.cryptoscope.io/tx/?txid=%s|https://evr-explorer-mainnet.ting.finance/index.html?route=TRANSACTION&id=%s"
 
 /* Default IPFS viewer */
 #define DEFAULT_IPFS_VIEWER "https://ipfs.io/ipfs/%s"


### PR DESCRIPTION
example urls:
- https://evr.cryptoscope.io/tx/?txid=19cd78a29df80aa9512b3cc30d3c0dd46b67176fcc6496b8de870506f28075f2
- https://evr-explorer-mainnet.ting.finance/index.html?route=TRANSACTION&id=c1f5160b208766e39dc5437ba6135d0d5b2cab6542fa65e5da5282428b77f5ea